### PR TITLE
Fixed a bug where it wasn't possible to mark a property as an @ObservedObject if it was injected as a propertyWrapper (need to investigage a better way to do this)

### DIFF
--- a/MyPodcast/MyPodcast/MyPodcastApp.swift
+++ b/MyPodcast/MyPodcast/MyPodcastApp.swift
@@ -10,13 +10,11 @@ import SwiftUI
 @main
 struct MyPodcastApp: App {
     @StateObject private var modelData = MockData()
-    let viewModelFactory = ViewModelFactory()
     
     var body: some Scene {
         WindowGroup {
             LandingScreen()
                 .environmentObject(modelData)
-                .environmentObject(viewModelFactory)
         }
     }
 }

--- a/MyPodcast/MyPodcast/Views/Explore/ExploreScreen.swift
+++ b/MyPodcast/MyPodcast/Views/Explore/ExploreScreen.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 struct ExploreScreen: View {
-    @InjectedDependency(\.exploreScreenViewModel) var viewModel: ExploreScreenViewModel
+    @ObservedObject var viewModel: ExploreScreenViewModel
 
     var body: some View {
         NavigationStack {
             List {
                 ForEach(viewModel.genres) { genre in
                     NavigationLink {
-                        GenreDetailScreen(genre: genre)
+                        GenreDetailScreen(viewModel: GenreViewModel(), genre: genre)
                     } label: {
                         GenreView(genre: genre)
                     }

--- a/MyPodcast/MyPodcast/Views/Genre/GenreDetailScreen.swift
+++ b/MyPodcast/MyPodcast/Views/Genre/GenreDetailScreen.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct GenreDetailScreen: View {
-    @InjectedDependency(\.genreViewModel) var viewModel: GenreViewModel
+    @ObservedObject var viewModel: GenreViewModel
     var genre: Genre
 
     var body: some View {

--- a/MyPodcast/MyPodcast/Views/Home/HomeScreen.swift
+++ b/MyPodcast/MyPodcast/Views/Home/HomeScreen.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct HomeScreen: View {
-    @InjectedDependency(\.homeScreenViewModel) var viewModel: HomeScreenViewModel
-
+    @ObservedObject var viewModel: HomeScreenViewModel
+    
     var body: some View {
         NavigationStack {
             List {

--- a/MyPodcast/MyPodcast/Views/MainScreen.swift
+++ b/MyPodcast/MyPodcast/Views/MainScreen.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct MainScreen: View {
     @State private var selection: Tab = .home
-    @EnvironmentObject var viewModelFactory: ViewModelFactory
     
     enum Tab {
         case home
@@ -20,13 +19,13 @@ struct MainScreen: View {
 
     var body: some View {
         TabView {
-            HomeScreen()
+            HomeScreen(viewModel: HomeScreenViewModel())
                 .tabItem {
                     Label("Home", systemImage: "house")
                 }
                 .tag(Tab.home)            
 
-            ExploreScreen()
+            ExploreScreen(viewModel: ExploreScreenViewModel())
                 .tabItem {
                     Label("Explore", systemImage: "signpost.right.and.left")
                 }

--- a/MyPodcast/MyPodcast/Views/Podcast/PodcastListPreview.swift
+++ b/MyPodcast/MyPodcast/Views/Podcast/PodcastListPreview.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PodcastListPreview: View {
-    @InjectedDependency(\.podcastListViewModel) var viewModel: PodcastListViewModel
+    @ObservedObject var viewModel: PodcastListViewModel
 
     var body: some View {
         List {

--- a/MyPodcast/MyPodcast/Views/Profile/ProfileScreen.swift
+++ b/MyPodcast/MyPodcast/Views/Profile/ProfileScreen.swift
@@ -15,7 +15,7 @@ struct ProfileScreen: View {
                 ProfileText()
             }
             Spacer()
-            PodcastListPreview()
+            PodcastListPreview(viewModel: PodcastListViewModel())
         }
     }
 }


### PR DESCRIPTION
- Fixed a bug where it wasn't possible to mark a property as an @ObservedObject if it was injected as a propertyWrapper (need to investigage a better way to do this)